### PR TITLE
修复 Android 4.4~5.0 启动闪退（复选框着色改用 AppCompat 兼容 API）

### DIFF
--- a/app/src/main/java/com/fntv/app/MainActivity.java
+++ b/app/src/main/java/com/fntv/app/MainActivity.java
@@ -305,7 +305,8 @@ public class MainActivity extends AppCompatActivity {
         cbWrap.setNextFocusDownId(R.id.btnLogin);
         cbWrap.setPadding((int)(12 * density), 0, (int)(12 * density), 0);
 
-        CheckBox cb = new CheckBox(this);
+        // AppCompatCheckBox：支持 API 19 上的 buttonTint 兼容着色
+        CheckBox cb = new androidx.appcompat.widget.AppCompatCheckBox(this);
         RelativeLayout.LayoutParams cbLp = new RelativeLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         cbLp.addRule(RelativeLayout.CENTER_VERTICAL);
@@ -315,14 +316,9 @@ public class MainActivity extends AppCompatActivity {
         cb.setTextColor(0xFFEEEEEE);
         cb.setTextSize(14);
         cb.setId(View.generateViewId());
-        try {
-            android.graphics.drawable.Drawable d = cb.getButtonDrawable();
-            if (d != null) {
-                d = androidx.core.graphics.drawable.DrawableCompat.wrap(d);
-                androidx.core.graphics.drawable.DrawableCompat.setTint(d.mutate(), 0xFF3370FF);
-                cb.setButtonDrawable(d);
-            }
-        } catch (Exception ignored) {}
+        // 兼容旧版本的勾选图标染蓝（替代 API 22 的 getButtonDrawable + setTint）
+        androidx.core.widget.CompoundButtonCompat.setButtonTintList(
+                cb, android.content.res.ColorStateList.valueOf(0xFF3370FF));
         cbWrap.addView(cb);
         cbWrap.setOnClickListener(new View.OnClickListener() {
             @Override


### PR DESCRIPTION
问题现象
在 Android 4.4系统上，应用启动后立即闪退，无法进入登录页。实测于 Android 4.4 机顶盒。

原因
MainActivity 构建登录页时调用了 CompoundButton.getButtonDrawable()，该方法为 Android 5.1（API 22）新增。在更低版本的系统上会触发 NoSuchMethodError —— 它是 Error 而非 Exception，原有的 catch (Exception) 无法捕获，导致进程直接崩溃。

修复方式
改用 AppCompatCheckBox + CompoundButtonCompat.setButtonTintList() 实现完全相同的勾选框染蓝效果（视觉效果不变），最低兼容 API 14，对 Android 5.1 及以上设备无任何影响。

验证
在 Android 4.4 机顶盒上实测：修复前启动闪退，修复后正常进入登录页并完成登录。